### PR TITLE
Fix opengapps.xml

### DIFF
--- a/opengapps.xml
+++ b/opengapps.xml
@@ -4,12 +4,12 @@
 <remote name="opengappsold" fetch="http://github.com/opengapps/"  />
 
 <project path="vendor/opengapps/build" name="aosp_build" revision="master" remote="opengappsold" />
-<project path="vendor/opengapps/sources/all" name="all" clone-depth="1" revision="master" remote="opengapps" />
+<project path="vendor/opengapps/sources/all" name="all.git" clone-depth="1" revision="master" remote="opengapps" />
 
 <!-- arm64 depends on arm -->
-<project path="vendor/opengapps/sources/arm" name="arm" clone-depth="1" revision="master" remote="opengapps" />
-<project path="vendor/opengapps/sources/arm64" name="arm64" clone-depth="1" revision="master" remote="opengapps" />
+<project path="vendor/opengapps/sources/arm" name="arm.git" clone-depth="1" revision="master" remote="opengapps" />
+<project path="vendor/opengapps/sources/arm64" name="arm64.git" clone-depth="1" revision="master" remote="opengapps" />
 
-<project path="vendor/opengapps/sources/x86" name="x86" clone-depth="1" revision="master" remote="opengapps" />
-<project path="vendor/opengapps/sources/x86_64" name="x86_64" clone-depth="1" revision="master" remote="opengapps" />
+<project path="vendor/opengapps/sources/x86" name="x86.git" clone-depth="1" revision="master" remote="opengapps" />
+<project path="vendor/opengapps/sources/x86_64" name="x86_64.git" clone-depth="1" revision="master" remote="opengapps" />
 </manifest>


### PR DESCRIPTION
Unlike GitHub, Gitlab doesn't redirect git client when it's accessing URL without '.git'.
Therefore, 'repo sync' throws 404s..