### PR TITLE
Update opengapps.xml

### DIFF
--- a/opengapps.xml
+++ b/opengapps.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-<remote name="opengapps" fetch="http://gitlab.nezorfla.me/opengapps/"  />
+<remote name="opengapps" fetch="http://gitlab.opengapps.org/opengapps/"  />
 <remote name="opengappsold" fetch="http://github.com/opengapps/"  />
 
 <project path="vendor/opengapps/build" name="aosp_build" revision="master" remote="opengappsold" />


### PR DESCRIPTION
As per https://github.com/opengapps/opengapps/issues/722#issuecomment-619373192, host gitlab.nezorfla.me no longer resolves. New host is gitlab.opengapps.org.
Seems that same changes were made to active branches in 2019.